### PR TITLE
Bump commons

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ The following inputs can be used as `step.with` keys
 | `aws_vpc_availability_zones` | String | Comma separated list of availability zones. Defaults to `aws_default_region+<random>` value. If a list is defined, the first zone will be the one used for the EC2 instance. |
 | `aws_vpc_id` | String | **Existing** AWS VPC ID to use. Accepts `vpc-###` values. |
 | `aws_vpc_subnet_id` | String | **Existing** AWS VPC Subnet ID. If none provided, will pick one. (Ideal when there's only one). |
+| `aws_vpc_enable_nat_gateway` | Boolean | Adds a NAT gateway for each public subnet. Defaults to `false`. |
+| `aws_vpc_single_nat_gateway` | Boolean | Toggles only one NAT gateway for all of the public subnets. Defaults to `false`. |
+| `aws_vpc_external_nat_ip_ids` | String | **Existing** comma separated list of IP IDs if reusing. (ElasticIPs). |
 | `aws_vpc_additional_tags` | JSON | Add additional tags to the terraform [default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider), any tags put here will be added to vpc provisioned resources.|
 <hr/>
 <br/>
@@ -232,6 +235,18 @@ The following inputs can be used as `step.with` keys
 | `aws_r53_create_root_cert` | Boolean | Generates and manage the root cert for the application. **See note**. Default is `false`. |
 | `aws_r53_create_sub_cert` | Boolean | Generates and manage the sub-domain certificate for the application. **See note**. Default is `false`. |
 | `aws_r53_additional_tags` | JSON | Add additional tags to the terraform [default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider), any tags put here will be added to R53 provisioned resources.|
+<hr/>
+<br/>
+
+
+#### **Action Outputs**
+| Name             | Description                        |
+|------------------|------------------------------------|
+| `aws_vpc_id` | The selected VPC ID used. |
+| `ecs_load_balancer_dns` | ECS ALB DNS Record. |
+| `ecs_dns_record` | ECS DNS URL. |
+| `ecs_sg_id` | ECS SG ID. |
+| `ecs_lb_sg_id` | ECS LB SG ID. |
 <hr/>
 <br/>
 

--- a/action.yaml
+++ b/action.yaml
@@ -190,6 +190,15 @@ inputs:
   aws_vpc_subnet_id:
     description: 'Specify a Subnet to be used with the instance. If none provided, will pick one.'
     required: false
+  aws_vpc_enable_nat_gateway:
+    description: 'Enables NAT gateway'
+    required: false
+  aws_vpc_single_nat_gateway:
+    description: 'Creates only one NAT gateway'
+    required: false
+  aws_vpc_external_nat_ip_ids:
+    description: 'Comma separated list of IP IDS to reuse in the NAT gateways'
+    required: false
   aws_vpc_additional_tags:
     description: 'A JSON object of additional tags that will be included on created resources. Example: `{"key1": "value1", "key2": "value2"}`'
     required: false
@@ -230,13 +239,19 @@ outputs:
   ecs_dns_record:
     description: "ECS DNS URL"
     value: ${{ steps.deploy.outputs.ecs_dns_record }}
-    
+  ecs_sg_id:
+    description: "ECS SG ID"
+    value: ${{ steps.deploy.outputs.ecs_sg_id }}
+  ecs_lb_sg_id:
+    description: "ECS LB SG ID"
+    value: ${{ steps.deploy.outputs.ecs_lb_sg_id }}
+
 runs:
   using: 'composite'
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@v0.0.11
+      uses: bitovi/github-actions-commons@v0.0.13
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}
@@ -309,6 +324,9 @@ runs:
         aws_vpc_availability_zones: ${{inputs.aws_vpc_availability_zones }}
         aws_vpc_id: ${{inputs.aws_vpc_id }}
         aws_vpc_subnet_id: ${{inputs.aws_vpc_subnet_id }}
+        aws_vpc_enable_nat_gateway: ${{ inputs.aws_vpc_enable_nat_gateway }}
+        aws_vpc_single_nat_gateway: ${{ inputs.aws_vpc_single_nat_gateway }}
+        aws_vpc_external_nat_ip_ids: ${{ inputs.aws_vpc_external_nat_ip_ids }}
         aws_vpc_additional_tags: ${{inputs.aws_vpc_additional_tags }}
 
         # AWS Route53 Domains abd Certificates

--- a/action.yaml
+++ b/action.yaml
@@ -56,6 +56,7 @@ inputs:
   aws_ecs_enable:
     description: 'Toggle ECS Creation'
     required: false
+    default: true
   aws_ecs_service_name:
     description: 'Elastic Container Service name'
     required: false


### PR DESCRIPTION
- Bump commons version to v0.0.13
- Added new VPC options (nat's)
- New outputs for ECS - See README
- Defaulting aws_ecs_enable to true