### PR TITLE
Ignore task defn

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ The following inputs can be used as `step.with` keys
 | `aws_ecs_service_launch_type`| String | Configuration type. Could be `EC2`, `FARGATE` or `EXTERNAL`. Defaults to `FARGATE`. |
 | `aws_ecs_task_type`| String | Configuration type. Could be `EC2`, `FARGATE` or empty. Will default to `aws_ecs_service_launch_type` if none defined. (Blank if `EXTERNAL`). |
 | `aws_ecs_task_name`| String | Elastic Container Service task name. If task is defined with a JSON file, should be the same as the container name. |
+| `aws_ecs_task_ignore_definition` | Boolean | Ignores changes done in the ECS Tasks and services. That way stack can be managed from outside Terraform. Defaults to `false` |  
 | `aws_ecs_task_execution_role`| String | Elastic Container Service task execution role name from IAM. Defaults to `ecsTaskExecutionRole`. |
 | `aws_ecs_task_json_definition_file`| String | Name of the json file containing task definition. Overrides every other input. |
 | `aws_ecs_task_network_mode`| String | Network type to use in task definition. One of `none`, `bridge`, `awsvpc`, and `host`. |

--- a/action.yaml
+++ b/action.yaml
@@ -307,7 +307,7 @@ runs:
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@add-aws_ecs_task_ignore_definition
+      uses: bitovi/github-actions-commons@v1
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}


### PR DESCRIPTION
Adds a boolean to create resources that ignores changes made in the ECS Tasks and services. 
That way, the ECS stack can be managed from outside Terraform. 