### PR TITLE
Skip DNS Recreation  and make ALB Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,11 @@ jobs:
 ```
 
 ## Extra advanced usage
-If you know what you are doing, you can play around defining a JSON file for the Task definition. That allows you more granular control of it.
+If you know what you are doing, you can play around defining a JSON file for the container definitions. That allows you more granular control of it.
+
+### Example Task Definition
+
+You can find an example ECS task definition in [`task-definition.example.json`](./task-definition.example.json).
 
 # Inputs
 
@@ -187,7 +191,7 @@ The following inputs can be used as `step.with` keys
 | `aws_ecs_task_name`| String | Elastic Container Service task name. If task is defined with a JSON file, should be the same as the container name. |
 | `aws_ecs_task_ignore_definition` | Boolean | Ignores changes done in the ECS Tasks and services. That way stack can be managed from outside Terraform. Defaults to `false` |  
 | `aws_ecs_task_execution_role`| String | Elastic Container Service task execution role name from IAM. Defaults to `ecsTaskExecutionRole`. |
-| `aws_ecs_task_json_definition_file`| String | Name of the json file containing task definition. Overrides every other input. |
+| `aws_ecs_task_json_definition_file`| String | Name of the json file containing container definitions. Overrides every other input. |
 | `aws_ecs_task_network_mode`| String | Network type to use in task definition. One of `none`, `bridge`, `awsvpc`, and `host`. |
 | `aws_ecs_task_cpu`| String | Task CPU Amount. |
 | `aws_ecs_task_mem`| String | Task Mem Amount. |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 This action uses the new GitHub Actions Commons, that is used by many Bitovi GitHub Actions, and so it's constantly evolving and improving.
 
+ ⚠️ BREAKING CHANGES INTRODUCED IN V1
+ Migrating from v0.1.* to v1.0.0 is possible. See [migration path](#migration-path) below.
+
 ![alt](https://bitovi-gha-pixel-tracker-deployment-main.bitovi-sandbox.com/pixel/VWxHSTB15-F2P3xFRAdVX)
 ## Action Summary
 With this action, you can create your ECS (Fargate or EC2) cluster, with tasks and service definitions in a matter of minutes! With an ALB, DNS and even Certificate (if in Route53)
@@ -41,7 +44,7 @@ jobs:
   deploy-ecs:
     runs-on: ubuntu-latest
     - name: Create Nginx example
-      uses: bitovi/github-actions-deploy-ecs@v0.1.6
+      uses: bitovi/github-actions-deploy-ecs@v1
       id: ecs
       with:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -80,7 +83,7 @@ jobs:
       url: ${{ steps.ecs.outputs.ecs_dns_record }}
     steps:
     - name: Create Nginx example
-      uses: bitovi/github-actions-deploy-ecs@v0.1.6
+      uses: bitovi/github-actions-deploy-ecs@v1
       id: ecs
       with:
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -302,6 +305,13 @@ The following inputs can be used as `step.with` keys
 ## Contributing
 We would love for you to contribute to [`bitovi/github-actions-deploy-ecs`](https://github.com/bitovi/github-actions-deploy-ecs).   [Issues](https://github.com/bitovi/github-actions-deploy-ecs/issues) and [Pull Requests](https://github.com/bitovi/github-actions-deploy-ecs/pulls) are welcome!
 
+## **Migration path**
+
+In order to migrate from v0 to v1, the following path should be taken. **Expect downtime**
+1. Set `aws_r53_enable` to `false`, run the action. 
+2. Bump to `v1` of the action with `aws_ecs_container_port` and `aws_ecs_lb_port` removed. Run the action.
+3. Add ports back. Run the action.
+4. Set `aws_r53_enable` to `true`, run the action. 
 
 ## Note about resource identifiers
 

--- a/action.yaml
+++ b/action.yaml
@@ -252,7 +252,7 @@ runs:
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@v1
+      uses: bitovi/github-actions-commons@ecs-http-listener-fix
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -252,7 +252,7 @@ runs:
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@main
+      uses: bitovi/github-actions-commons@ecs-firelens
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -137,16 +137,25 @@ inputs:
     required: false
   aws_ecs_cloudwatch_enable:
     description: "Toggle cloudwatch for ECS. Default 'false'"
-    reuired: false
+    required: false
   aws_ecs_cloudwatch_lg_name:
     description: "Log group name. Will default to aws_identifier if none."
-    reuired: false
+    required: false
+  aws_ecs_cloudwatch_log_driver:
+    description: "Log driver to use for the ECS task."
+    required: false
+  aws_ecs_firelens_output_type:
+    description: "The type of output for FireLens."
+    required: false
+  aws_ecs_firelens_output_options:
+    description: "The options for the FireLens output."
+    required: false
   aws_ecs_cloudwatch_skip_destroy:
     description: "Toggle deletion or not when destroying the stack."
-    reuired: false
+    required: false
   aws_ecs_cloudwatch_retention_days:
     description: "Number of days to retain logs. 0 to never expire. Default '14'"
-    reuired: false
+    required: false
   aws_ecs_additional_tags:
     description: 'A list of strings that will be added to created resources'
     required: false
@@ -306,6 +315,9 @@ runs:
         aws_ecs_autoscaling_max_cpu: ${{ inputs.aws_ecs_autoscaling_max_cpu }}
         aws_ecs_cloudwatch_enable: ${{ inputs.aws_ecs_cloudwatch_enable }}
         aws_ecs_cloudwatch_lg_name: ${{ inputs.aws_ecs_cloudwatch_lg_name }}
+        aws_ecs_cloudwatch_log_driver: ${{ inputs.aws_ecs_cloudwatch_log_driver }}
+        aws_ecs_firelens_output_type: ${{ inputs.aws_ecs_firelens_output_type }}
+        aws_ecs_firelens_output_options: ${{ inputs.aws_ecs_firelens_output_options }}
         aws_ecs_cloudwatch_skip_destroy: ${{ inputs.aws_ecs_cloudwatch_skip_destroy }}
         aws_ecs_cloudwatch_retention_days: ${{ inputs.aws_ecs_cloudwatch_retention_days }}
         aws_ecs_additional_tags: ${{ inputs.aws_ecs_additional_tags }}

--- a/action.yaml
+++ b/action.yaml
@@ -144,15 +144,6 @@ inputs:
   aws_ecs_cloudwatch_lg_name:
     description: "Log group name. Will default to aws_identifier if none."
     required: false
-  aws_ecs_cloudwatch_log_driver:
-    description: "Log driver to use for the ECS task."
-    required: false
-  aws_ecs_firelens_output_type:
-    description: "The type of output for FireLens."
-    required: false
-  aws_ecs_firelens_output_options:
-    description: "The options for the FireLens output."
-    required: false
   aws_ecs_cloudwatch_skip_destroy:
     description: "Toggle deletion or not when destroying the stack."
     required: false
@@ -371,9 +362,6 @@ runs:
         aws_ecs_autoscaling_max_cpu: ${{ inputs.aws_ecs_autoscaling_max_cpu }}
         aws_ecs_cloudwatch_enable: ${{ inputs.aws_ecs_cloudwatch_enable }}
         aws_ecs_cloudwatch_lg_name: ${{ inputs.aws_ecs_cloudwatch_lg_name }}
-        aws_ecs_cloudwatch_log_driver: ${{ inputs.aws_ecs_cloudwatch_log_driver }}
-        aws_ecs_firelens_output_type: ${{ inputs.aws_ecs_firelens_output_type }}
-        aws_ecs_firelens_output_options: ${{ inputs.aws_ecs_firelens_output_options }}
         aws_ecs_cloudwatch_skip_destroy: ${{ inputs.aws_ecs_cloudwatch_skip_destroy }}
         aws_ecs_cloudwatch_retention_days: ${{ inputs.aws_ecs_cloudwatch_retention_days }}
         aws_ecs_additional_tags: ${{ inputs.aws_ecs_additional_tags }}

--- a/action.yaml
+++ b/action.yaml
@@ -344,6 +344,7 @@ runs:
         aws_ecs_service_launch_type: ${{ inputs.aws_ecs_service_launch_type }}
         aws_ecs_task_type: ${{ inputs.aws_ecs_task_type }}
         aws_ecs_task_name: ${{ inputs.aws_ecs_task_name }}
+        aws_ecs_task_ignore_definition: ${{ inputs.aws_ecs_task_ignore_definition }}
         aws_ecs_task_execution_role: ${{ inputs.aws_ecs_task_execution_role }}
         aws_ecs_task_json_definition_file: ${{ inputs.aws_ecs_task_json_definition_file }}
         aws_ecs_task_network_mode: ${{ inputs.aws_ecs_task_network_mode }}

--- a/action.yaml
+++ b/action.yaml
@@ -316,7 +316,7 @@ runs:
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@main
+      uses: bitovi/github-actions-commons@fix-ecs-lb-introduced-issue
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -307,7 +307,7 @@ runs:
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@main
+      uses: bitovi/github-actions-commons@ecs-skip-r53-dependency
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -307,7 +307,7 @@ runs:
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@fix-ecs-lb-introduced-issue
+      uses: bitovi/github-actions-commons@main
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -307,7 +307,7 @@ runs:
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@ecs-skip-r53-dependency
+      uses: bitovi/github-actions-commons@v2
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -252,7 +252,7 @@ runs:
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@ecs-http-listener-fix
+      uses: bitovi/github-actions-commons@main
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -313,7 +313,7 @@ runs:
   steps:
     - name: Deploy with BitOps
       id: deploy
-      uses: bitovi/github-actions-commons@ecs-firelens
+      uses: bitovi/github-actions-commons@main
       with:
         # Current repo vars
         gh_action_repo: ${{ github.action_path }}

--- a/task-definition.example.json
+++ b/task-definition.example.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "test-world-staging-api",
+    "image": "nginx:alpine",
+    "essential": true,
+    "cpu": 256,
+    "memory": 512,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "protocol": "tcp",
+        "hostPort": 80,
+        "appProtocol": "http"
+      }
+    ],
+    "environment": [],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "/ecs/my-task-family",
+        "awslogs-region": "us-east-1",
+        "awslogs-stream-prefix": "api"
+      }
+    }
+  }
+]


### PR DESCRIPTION
- Fix issue with DNS record getting recreated each time, causing downtime.
- Make ALB optional, so when no port nor load balancer is needed, it won't get created.
- Add task definition example 